### PR TITLE
feat: oauth for authentik

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,14 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      SETUPTOOLS_SCM_PRETEND_VERSION: "2025.0.0"
       UV_PYTHON_PREFERENCE: managed
       UV_PYTHON: "3.13"
       NOM_DB_NAME: gha_test
       NOM_DB_HOST: localhost
       NOM_DB_PORT: "52432"
       NOM_DB_USER: gha
-      NOM_OAUTH_KEY: bogon
-      NOM_OAUTH_SECRET: bogon
+      NOM_OAUTH_CLIENT_ID: bogon
+      NOM_OAUTH_CLIENT_SECRET: bogon
       NOM_REDIS_HOST: localhost
       NOM_EMAIL_HOST: localhost
 
@@ -81,7 +80,13 @@ jobs:
           echo "COMPOSE_PROJECT_NAME=nomnom-ci-${CI_SERVICES_SUFFIX}" >> "$GITHUB_ENV"
 
       - name: Start the database
-        run: docker compose up --wait db redis mailcatcher
+        run: |
+          set -eu -o pipefail
+          docker compose up --wait db redis mailcatcher
+
+          # set the redis and DB ports in the environment
+          echo "NOM_DB_PORT=$(docker compose port db 5432 | awk -F: '{print $2}')" >> "$GITHUB_ENV"
+          echo "NOM_REDIS_PORT=$(docker compose port redis 6379 | awk -F: '{print $2}')" >> "$GITHUB_ENV"
 
       - name: Run tests
         run: |

--- a/lacon_v_app/auth.py
+++ b/lacon_v_app/auth.py
@@ -1,0 +1,176 @@
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from social_core.backends.open_id_connect import OpenIdConnectAuth
+from social_core.strategy import BaseStrategy
+
+UserModel = get_user_model()
+
+
+class LaconMemberBackend(OpenIdConnectAuth):
+    name = "lacon"
+
+    DEFAULT_SCOPE = ["openid", "profile", "email", "membership"]
+
+
+def adapt_regid_to_username(
+    strategy: BaseStrategy,
+    details: dict[str, Any],
+    user=UserModel,
+    *args,
+    response: dict[str, Any],
+    **kwargs,
+) -> None:
+    """Extract the reg-id if provided and make it available as a username and member_number"""
+    try:
+        member_id = response["reg-id"]
+    except KeyError:
+        # log a warning, maybe?
+        return
+
+    details["username"] = member_id
+    details["member_number"] = member_id
+
+    # nomnom's social auth integration uses this key.
+    wsfs_status_key = strategy.setting("WSFS_STATUS_KEY", default="wsfs_status")
+    if wsfs_status_key:
+        details[wsfs_status_key] = response.get(
+            "membership_type", "Unknown Member Type"
+        )
+    return
+
+
+def get_wsfs_permissions(
+    strategy: BaseStrategy,
+    details: dict[str, Any],
+    user=UserModel,
+    *args,
+    response: dict[str, Any],
+    **kwargs,
+) -> None:
+    """Extract WSFS permissions from response"""
+    details["can_nominate"] = response.get("hugos-can-nominate", False)
+    details["can_vote"] = response.get("hugos-can-vote", False)
+    details["site_selection_can_vote"] = response.get("site-selection-can-vote", False)
+
+    # Map groups to Django permissions
+    groups = response.get("groups", [])
+    details["is_admin"] = "App Admins" in groups
+
+    return
+
+
+def adapt_personal_information(
+    strategy: BaseStrategy,
+    details: dict[str, Any],
+    user=UserModel,
+    *args,
+    response: dict[str, Any],
+    **kwargs,
+) -> None:
+    """Adapt personal information from response using field priority rules"""
+    # Name priority: preferred_name > given_name > nickname
+    preferred_name = response.get("preferred_name")
+    given_name = response.get("given_name")
+    nickname = response.get("nickname")
+
+    if preferred_name:
+        name_to_use = preferred_name
+    elif given_name:
+        name_to_use = given_name
+    else:
+        name_to_use = nickname
+
+    if name_to_use:
+        # Split name for first/last if possible
+        name_parts = name_to_use.split()
+        details["first_name"] = name_parts[0]
+        if len(name_parts) > 1:
+            details["last_name"] = " ".join(name_parts[1:])
+
+        # Store preferred name separately
+        details["preferred_name"] = name_to_use
+
+    # Map email
+    email = response.get("email")
+    if email:
+        details["email"] = email
+
+    # Map membership information
+    details["membership_type"] = response.get("membership-type")
+    details["is_in_person"] = response.get("is-in-person", False)
+    return
+
+
+def store_full_membership_data(
+    strategy: BaseStrategy,
+    details: dict[str, Any],
+    user=UserModel,
+    *args,
+    response: dict[str, Any],
+    **kwargs,
+) -> None:
+    """Store full membership response data for reference"""
+    details["full_response"] = response.copy()
+    return
+
+
+def create_user(
+    strategy: BaseStrategy,
+    details: dict[str, Any],
+    user=None,
+    *args,
+    response: dict[str, Any],
+    **kwargs,
+) -> dict[str, Any]:
+    """Create user with fields extracted by adapt_personal_information"""
+    if user:
+        # User already exists, return early
+        return {"user": user}
+
+    # Extract user creation fields from details
+    username = details.get("username")
+    if not username:
+        # Username is required for user creation, generate one if missing
+        # This could happen if reg-id is not provided in the response
+        username = f"user_{response.get('email', 'anonymous')}"
+
+    user_fields = {
+        "username": username,
+        "email": details.get("email", ""),
+        "first_name": details.get("first_name", ""),
+        "last_name": details.get("last_name", ""),
+    }
+
+    # Remove None values to avoid validation errors, but keep username
+    user_fields = {k: v for k, v in user_fields.items() if v is not None}
+
+    # Create the user
+    created_user = UserModel.objects.create_user(**user_fields)
+
+    return {"user": created_user, "is_new": True}
+
+
+def set_member_details(
+    strategy: BaseStrategy,
+    details: dict[str, Any],
+    user=None,
+    *args,
+    response: dict[str, Any],
+    **kwargs,
+) -> None:
+    """Set additional member details on the user object"""
+    if not user:
+        return
+
+    # set the ticket number used by the WSFS membership associator.
+    details["ticket_number"] = details["member_number"]
+
+    # Set admin status
+    if details.get("is_admin") is not None:
+        user.is_staff = details["is_admin"]
+
+    # Save the user with updated fields
+    user.save()
+
+    return

--- a/lacon_v_app/templates/bits/login_forms.html
+++ b/lacon_v_app/templates/bits/login_forms.html
@@ -18,5 +18,11 @@
             or add a convention app to settings with NOM_CONVENTION_APP and provide
             a different login scheme.
         {% endif %}
+        <div class="d-inline-flex gap-2 mb-5">
+            <a href="{% url "social:begin" "lacon" %}?next={{ request.path }}">
+                <button class="d-inline-flex align-items-center btn btn-primary btn-lg px-4 rounded-pill"
+                        type="button">Log in with {{ CONVENTION_NAME }} Registration</button>
+            </a>
+        </div>
     </div>
 </div>

--- a/lacon_v_app/tests/data/app-admin.json
+++ b/lacon_v_app/tests/data/app-admin.json
@@ -1,0 +1,22 @@
+{
+  "access_token": "BOGON",
+  "email": "chris.rose@lacon.org",
+  "email_verified": false,
+  "expires_in": 300,
+  "given_name": "Chris Rose",
+  "groups": ["App Admins"],
+  "hugos-can-nominate": true,
+  "hugos-can-vote": true,
+  "id_token": "BOGON",
+  "is-in-person": false,
+  "membership-type": "Unknown",
+  "name": "Chris Rose",
+  "nickname": "rose.admin",
+  "nonce": "BOGON",
+  "preferred_username": "rose.admin",
+  "reg-id": "test-chrisrose.staging.id",
+  "scope": "profile email membership openid",
+  "site-selection-can-vote": false,
+  "sub": "BOGON",
+  "token_type": "Bearer"
+}

--- a/lacon_v_app/tests/data/full-member.json
+++ b/lacon_v_app/tests/data/full-member.json
@@ -1,0 +1,22 @@
+{
+  "access_token": "BOGON",
+  "email": "chris.rose@lacon.org",
+  "email_verified": false,
+  "expires_in": 300,
+  "given_name": "Chris Rose",
+  "groups": [],
+  "hugos-can-nominate": true,
+  "hugos-can-vote": true,
+  "id_token": "BOGON",
+  "is-in-person": false,
+  "membership-type": "Unknown",
+  "name": "Chris Rose",
+  "nickname": "rose.admin",
+  "nonce": "BOGON",
+  "preferred_username": "rose.admin",
+  "reg-id": "test-chrisrose.staging.id",
+  "scope": "profile email membership openid",
+  "site-selection-can-vote": false,
+  "sub": "BOGON",
+  "token_type": "Bearer"
+}

--- a/lacon_v_app/tests/data/nominator.json
+++ b/lacon_v_app/tests/data/nominator.json
@@ -1,0 +1,22 @@
+{
+  "access_token": "BOGON",
+  "email": "chris.rose@lacon.org",
+  "email_verified": false,
+  "expires_in": 300,
+  "given_name": "Chris Rose",
+  "groups": [],
+  "hugos-can-nominate": true,
+  "hugos-can-vote": false,
+  "id_token": "BOGON",
+  "is-in-person": false,
+  "membership-type": "Unknown",
+  "name": "Chris Rose",
+  "nickname": "rose.admin",
+  "nonce": "BOGON",
+  "preferred_username": "rose.admin",
+  "reg-id": "test-chrisrose.staging.id",
+  "scope": "profile email membership openid",
+  "site-selection-can-vote": false,
+  "sub": "BOGON",
+  "token_type": "Bearer"
+}

--- a/lacon_v_app/tests/data/voter.json
+++ b/lacon_v_app/tests/data/voter.json
@@ -1,0 +1,22 @@
+{
+  "access_token": "BOGON",
+  "email": "chris.rose@lacon.org",
+  "email_verified": false,
+  "expires_in": 300,
+  "given_name": "Chris Rose",
+  "groups": [],
+  "hugos-can-nominate": false,
+  "hugos-can-vote": true,
+  "id_token": "BOGON",
+  "is-in-person": false,
+  "membership-type": "Unknown",
+  "name": "Chris Rose",
+  "nickname": "rose.admin",
+  "nonce": "BOGON",
+  "preferred_username": "rose.admin",
+  "reg-id": "test-chrisrose.staging.id",
+  "scope": "profile email membership openid",
+  "site-selection-can-vote": false,
+  "sub": "BOGON",
+  "token_type": "Bearer"
+}

--- a/lacon_v_app/tests/test_auth.py
+++ b/lacon_v_app/tests/test_auth.py
@@ -1,0 +1,604 @@
+import pytest
+from django.contrib.auth import get_user_model
+from faker import Faker
+from social_core.tests.models import TestStorage
+from social_core.tests.strategy import TestStrategy
+
+from lacon_v_app.auth import (
+    adapt_personal_information,
+    adapt_regid_to_username,
+    create_user,
+    get_wsfs_permissions,
+    set_member_details,
+    store_full_membership_data,
+)
+
+User = get_user_model()
+fake = Faker()
+
+
+@pytest.fixture
+def mock_strategy():
+    """Mock social auth strategy"""
+    return TestStrategy(storage=TestStorage())
+
+
+@pytest.fixture
+def test_user(db):
+    """Create a test user using the actual Django User model"""
+    return User.objects.create_user(
+        username=fake.user_name(),
+        email=fake.email(),
+        first_name=fake.first_name(),
+        last_name=fake.last_name(),
+    )
+
+
+def generate_auth_response(
+    has_admin_group=False,
+    can_nominate=False,
+    can_vote=False,
+    can_site_selection_vote=False,
+    membership_type="Unknown",
+    is_in_person=False,
+    reg_id_format="standard",  # standard, hyphenated, dots, short
+    use_preferred_name=True,
+    use_given_name=True,
+    use_nickname=True,
+):
+    """Generate a fake auth response with the specified parameters"""
+    base_response = {
+        "access_token": fake.uuid4(),
+        "email_verified": fake.boolean(),
+        "expires_in": fake.random_int(min=300, max=3600),
+        "id_token": fake.uuid4(),
+        "nonce": fake.uuid4(),
+        "scope": "profile email membership openid",
+        "sub": fake.uuid4(),
+        "token_type": "Bearer",
+        "email": fake.email(),
+        "hugos-can-nominate": can_nominate,
+        "hugos-can-vote": can_vote,
+        "site-selection-can-vote": can_site_selection_vote,
+        "membership-type": membership_type,
+        "is-in-person": is_in_person,
+    }
+
+    # Generate groups
+    groups = []
+    if has_admin_group:
+        groups.append("App Admins")
+    # Add some random groups for variation
+    for _ in range(fake.random_int(min=0, max=3)):
+        groups.append(fake.word().title() + " Group")
+    base_response["groups"] = groups
+
+    # Generate reg-id in various formats
+    base_name = fake.user_name()
+    if reg_id_format == "standard":
+        base_response["reg-id"] = f"member-{fake.random_int(min=1000, max=99999)}"
+    elif reg_id_format == "hyphenated":
+        base_response["reg-id"] = f"test-{base_name}.staging.id"
+    elif reg_id_format == "dots":
+        base_response["reg-id"] = f"{base_name}.{fake.random_int(min=100, max=999)}.id"
+    elif reg_id_format == "short":
+        base_response["reg-id"] = f"{fake.random_int(min=100, max=999)}"
+
+    # Generate names
+    first_name = fake.first_name()
+    last_name = fake.last_name()
+
+    if use_preferred_name:
+        base_response["preferred_name"] = f"{first_name} {last_name}"
+
+    if use_given_name:
+        base_response["given_name"] = f"{first_name} {last_name}"
+        base_response["name"] = f"{first_name} {last_name}"
+
+    if use_nickname:
+        base_response["nickname"] = fake.user_name()
+        base_response["preferred_username"] = base_response["nickname"]
+
+    return base_response
+
+
+# Test parameter combinations
+ADMIN_PERMISSIONS = [True, False]
+admin_permissions_param = pytest.mark.parametrize(
+    "has_admin_group", ADMIN_PERMISSIONS, ids=["admin", "non_admin"]
+)
+
+HUGO_PERMISSIONS = [
+    (False, False),  # can't nominate, can't vote
+    (True, False),  # can nominate, can't vote
+    (False, True),  # can't nominate, can vote
+    (True, True),  # can nominate and vote
+]
+hugo_permissions_param = pytest.mark.parametrize(
+    "can_nominate,can_vote",
+    HUGO_PERMISSIONS,
+    ids=["none", "nominate_only", "vote_only", "both"],
+)
+
+MEMBERSHIP_TYPES = ["Unknown", "Adult", "Supporting", "Youth", "Child"]
+membership_type_param = pytest.mark.parametrize("membership_type", MEMBERSHIP_TYPES)
+
+REG_ID_FORMATS = ["standard", "hyphenated", "dots", "short"]
+reg_id_format_param = pytest.mark.parametrize("reg_id_format", REG_ID_FORMATS)
+
+NAME_VARIATIONS = [
+    (True, True, True),  # has preferred, given, nickname
+    (True, False, True),  # has preferred, no given, has nickname
+    (False, True, True),  # no preferred, has given, has nickname
+    (False, False, True),  # no preferred, no given, has nickname
+    (False, True, False),  # no preferred, has given, no nickname
+]
+name_variations_param = pytest.mark.parametrize(
+    "use_preferred,use_given,use_nickname",
+    NAME_VARIATIONS,
+    ids=["all_names", "no_given", "no_preferred", "only_nickname", "given_only"],
+)
+in_person_param = pytest.mark.parametrize(
+    "is_in_person", [True, False], ids=["in_person", "virtual"]
+)
+
+site_selection_param = pytest.mark.parametrize(
+    "can_site_vote", [True, False], ids=["can_site_vote", "cannot_site_vote"]
+)
+
+
+class TestAdaptRegidToUsername:
+    @reg_id_format_param
+    def test_extracts_regid_as_username_and_member_number(
+        self, mock_strategy, test_user, reg_id_format
+    ):
+        response = generate_auth_response(reg_id_format=reg_id_format)
+        details = {}
+
+        adapt_regid_to_username(mock_strategy, details, test_user, response=response)
+
+        assert details["username"] == response["reg-id"]
+        assert details["member_number"] == response["reg-id"]
+
+    def test_handles_missing_regid(self, mock_strategy, test_user):
+        details = {}
+        response = {"email": fake.email()}
+
+        adapt_regid_to_username(mock_strategy, details, test_user, response=response)
+
+        assert "username" not in details
+        assert "member_number" not in details
+
+    @reg_id_format_param
+    def test_preserves_existing_details(self, mock_strategy, test_user, reg_id_format):
+        response = generate_auth_response(reg_id_format=reg_id_format)
+        details = {"existing_field": "preserved"}
+
+        adapt_regid_to_username(mock_strategy, details, test_user, response=response)
+
+        assert details["existing_field"] == "preserved"
+        assert details["username"] == response["reg-id"]
+
+
+class TestGetWsfsPermissions:
+    @hugo_permissions_param
+    def test_extracts_hugo_permissions(
+        self, mock_strategy, test_user, can_nominate, can_vote
+    ):
+        response = generate_auth_response(can_nominate=can_nominate, can_vote=can_vote)
+        details = {}
+
+        get_wsfs_permissions(mock_strategy, details, test_user, response=response)
+
+        assert details["can_nominate"] is can_nominate
+        assert details["can_vote"] is can_vote
+
+    @site_selection_param
+    def test_extracts_site_selection_permissions(
+        self, mock_strategy, test_user, can_site_vote
+    ):
+        response = generate_auth_response(can_site_selection_vote=can_site_vote)
+        details = {}
+
+        get_wsfs_permissions(mock_strategy, details, test_user, response=response)
+
+        assert details["site_selection_can_vote"] is can_site_vote
+
+    @admin_permissions_param
+    def test_detects_admin_group(self, mock_strategy, test_user, has_admin_group):
+        response = generate_auth_response(has_admin_group=has_admin_group)
+        details = {}
+
+        get_wsfs_permissions(mock_strategy, details, test_user, response=response)
+
+        assert details["is_admin"] is has_admin_group
+
+    def test_handles_missing_permissions(self, mock_strategy, test_user):
+        details = {}
+        response = {"email": fake.email()}
+
+        get_wsfs_permissions(mock_strategy, details, test_user, response=response)
+
+        assert details["can_nominate"] is False
+        assert details["can_vote"] is False
+        assert details["site_selection_can_vote"] is False
+        assert details["is_admin"] is False
+
+
+class TestAdaptPersonalInformation:
+    @name_variations_param
+    def test_name_handling_variations(
+        self, mock_strategy, test_user, use_preferred, use_given, use_nickname
+    ):
+        response = generate_auth_response(
+            use_preferred_name=use_preferred,
+            use_given_name=use_given,
+            use_nickname=use_nickname,
+        )
+        details = {}
+
+        adapt_personal_information(mock_strategy, details, test_user, response=response)
+
+        # Test that we get some kind of name
+        if use_preferred:
+            expected_name = response["preferred_name"]
+            name_parts = expected_name.split()
+            assert details["first_name"] == name_parts[0]
+            if len(name_parts) > 1:
+                assert details["last_name"] == " ".join(name_parts[1:])
+            assert details["preferred_name"] == expected_name
+        elif use_given:
+            expected_name = response["given_name"]
+            name_parts = expected_name.split()
+            assert details["first_name"] == name_parts[0]
+            if len(name_parts) > 1:
+                assert details["last_name"] == " ".join(name_parts[1:])
+            assert details["preferred_name"] == expected_name
+        elif use_nickname:
+            assert details["first_name"] == response["nickname"]
+            assert details["preferred_name"] == response["nickname"]
+
+    @membership_type_param
+    @in_person_param
+    def test_maps_membership_info(
+        self, mock_strategy, test_user, membership_type, is_in_person
+    ):
+        response = generate_auth_response(
+            membership_type=membership_type, is_in_person=is_in_person
+        )
+        details = {}
+
+        adapt_personal_information(mock_strategy, details, test_user, response=response)
+
+        assert details["membership_type"] == membership_type
+        assert details["is_in_person"] is is_in_person
+
+    def test_maps_email(self, mock_strategy, test_user):
+        response = generate_auth_response()
+        details = {}
+
+        adapt_personal_information(mock_strategy, details, test_user, response=response)
+
+        assert details["email"] == response["email"]
+
+    def test_handles_missing_fields(self, mock_strategy, test_user):
+        details = {}
+        response = {}
+
+        adapt_personal_information(mock_strategy, details, test_user, response=response)
+
+        assert "first_name" not in details
+        assert "email" not in details
+        assert details["membership_type"] is None
+        assert details["is_in_person"] is False
+
+
+class TestStoreFullMembershipData:
+    def test_stores_complete_response(self, mock_strategy, test_user):
+        response = generate_auth_response()
+        details = {}
+
+        store_full_membership_data(mock_strategy, details, test_user, response=response)
+
+        assert details["full_response"] == response
+        assert details["full_response"]["reg-id"] == response["reg-id"]
+        assert details["full_response"]["email"] == response["email"]
+
+    def test_creates_copy_not_reference(self, mock_strategy, test_user):
+        response = generate_auth_response()
+        details = {}
+
+        store_full_membership_data(mock_strategy, details, test_user, response=response)
+
+        # Modify original response
+        response["new_field"] = "added"
+
+        # Stored copy should not be affected
+        assert "new_field" not in details["full_response"]
+
+    def test_handles_empty_response(self, mock_strategy, test_user):
+        details = {}
+        response = {}
+
+        store_full_membership_data(mock_strategy, details, test_user, response=response)
+
+        assert details["full_response"] == {}
+
+
+class TestPipelineIntegration:
+    @admin_permissions_param
+    @hugo_permissions_param
+    @membership_type_param
+    @reg_id_format_param
+    def test_full_pipeline_variations(
+        self,
+        mock_strategy,
+        test_user,
+        has_admin_group,
+        can_nominate,
+        can_vote,
+        membership_type,
+        reg_id_format,
+    ):
+        """Test running all pipeline functions with various parameter combinations"""
+        response = generate_auth_response(
+            has_admin_group=has_admin_group,
+            can_nominate=can_nominate,
+            can_vote=can_vote,
+            membership_type=membership_type,
+            reg_id_format=reg_id_format,
+        )
+        details = {}
+
+        # Run pipeline functions in order
+        adapt_regid_to_username(mock_strategy, details, test_user, response=response)
+        get_wsfs_permissions(mock_strategy, details, test_user, response=response)
+        adapt_personal_information(mock_strategy, details, test_user, response=response)
+        store_full_membership_data(mock_strategy, details, test_user, response=response)
+
+        # Verify all expected fields are set
+        assert details["username"] == response["reg-id"]
+        assert details["member_number"] == response["reg-id"]
+        assert details["can_nominate"] is can_nominate
+        assert details["can_vote"] is can_vote
+        assert details["is_admin"] is has_admin_group
+        assert details["membership_type"] == membership_type
+        assert details["full_response"] == response
+
+        # Verify name fields are populated
+        assert "first_name" in details
+        assert "preferred_name" in details
+        assert "email" in details
+
+    def test_pipeline_preserves_order_independence(self, mock_strategy, test_user):
+        """Test that pipeline functions don't interfere with each other"""
+        response = generate_auth_response()
+        details1 = {}
+        details2 = {}
+
+        # Run in different orders
+        adapt_regid_to_username(mock_strategy, details1, test_user, response=response)
+        adapt_personal_information(
+            mock_strategy, details1, test_user, response=response
+        )
+        get_wsfs_permissions(mock_strategy, details1, test_user, response=response)
+
+        get_wsfs_permissions(mock_strategy, details2, test_user, response=response)
+        adapt_regid_to_username(mock_strategy, details2, test_user, response=response)
+        adapt_personal_information(
+            mock_strategy, details2, test_user, response=response
+        )
+
+        # Results should be identical regardless of order
+        for key in ["username", "can_nominate", "first_name", "email"]:
+            assert details1[key] == details2[key]
+
+
+class TestCreateUser:
+    @reg_id_format_param
+    def test_creates_new_user_with_pipeline_data(
+        self, mock_strategy, db, reg_id_format
+    ):
+        """Test creating a new user with data from pipeline functions"""
+        response = generate_auth_response(reg_id_format=reg_id_format)
+        details = {}
+
+        # Run pipeline functions to populate details
+        adapt_regid_to_username(mock_strategy, details, None, response=response)
+        adapt_personal_information(mock_strategy, details, None, response=response)
+
+        # Now create user with pipeline data
+        result = create_user(mock_strategy, details, user=None, response=response)
+
+        assert result["is_new"] is True
+        user = result["user"]
+        assert user.username == response["reg-id"]
+        assert user.email == response["email"]
+        assert "first_name" in details
+
+    def test_creates_user_with_partial_fields(self, mock_strategy, db):
+        """Test creating a user when some fields are missing"""
+        details = {
+            "username": fake.user_name(),
+            "email": fake.email(),
+            "first_name": fake.first_name(),
+            # last_name is missing
+        }
+        response = {}
+
+        result = create_user(mock_strategy, details, user=None, response=response)
+
+        assert result["is_new"] is True
+        user = result["user"]
+        assert user.username == details["username"]
+        assert user.email == details["email"]
+        assert user.first_name == details["first_name"]
+        assert user.last_name == ""  # should default to empty string
+
+    def test_handles_empty_email(self, mock_strategy, db):
+        """Test creating a user with empty email"""
+        details = {
+            "username": fake.user_name(),
+            "first_name": fake.first_name(),
+            "last_name": fake.last_name(),
+        }
+        response = {}
+
+        result = create_user(mock_strategy, details, user=None, response=response)
+
+        assert result["is_new"] is True
+        user = result["user"]
+        assert user.username == details["username"]
+        assert user.email == ""
+
+    def test_returns_existing_user_without_creating_new_one(
+        self, mock_strategy, test_user
+    ):
+        """Test that if user already exists, it returns the existing user"""
+        details = {
+            "username": fake.user_name(),
+            "email": fake.email(),
+        }
+        response = {}
+
+        result = create_user(mock_strategy, details, user=test_user, response=response)
+
+        assert result["user"] == test_user
+        assert "is_new" not in result
+
+    def test_filters_out_none_values(self, mock_strategy, db):
+        """Test that None values are filtered out to avoid validation errors"""
+        details = {
+            "username": fake.user_name(),
+            "email": None,  # This should be filtered out
+            "first_name": fake.first_name(),
+            "last_name": None,  # This should be filtered out
+        }
+        response = {}
+
+        result = create_user(mock_strategy, details, user=None, response=response)
+
+        assert result["is_new"] is True
+        user = result["user"]
+        assert user.username == details["username"]
+        assert user.first_name == details["first_name"]
+        # None values should not cause issues
+
+    def test_with_missing_username(self, mock_strategy, db):
+        """Test behavior when username is missing"""
+        email = fake.email()
+        details = {
+            "email": email,
+            "first_name": fake.first_name(),
+            "last_name": fake.last_name(),
+        }
+        response = {"email": email}
+
+        result = create_user(mock_strategy, details, user=None, response=response)
+
+        assert result["is_new"] is True
+        user = result["user"]
+        # Username should be generated from email when missing
+        assert user.username == f"user_{email}"
+        assert user.email == email
+
+    def test_with_missing_username_and_email(self, mock_strategy, db):
+        """Test behavior when both username and email are missing"""
+        details = {
+            "first_name": fake.first_name(),
+            "last_name": fake.last_name(),
+        }
+        response = {}
+
+        result = create_user(mock_strategy, details, user=None, response=response)
+
+        assert result["is_new"] is True
+        user = result["user"]
+        # Username should fallback to anonymous when no email available
+        assert user.username == "user_anonymous"
+        assert user.email == ""
+
+
+class TestSetMemberDetails:
+    def test_does_nothing_when_user_is_none(self, mock_strategy):
+        """Test that function returns early when user is None"""
+        details = {"preferred_name": fake.name()}
+        response = {}
+
+        # Should not raise any errors
+        result = set_member_details(
+            mock_strategy, details, user=None, response=response
+        )
+        assert result is None
+
+    @admin_permissions_param
+    def test_sets_admin_permissions(self, mock_strategy, test_user, has_admin_group):
+        """Test setting admin permissions on user"""
+        details = {
+            "is_admin": has_admin_group,
+            "member_number": fake.random_int(min=1000, max=9999),
+        }
+        response = {}
+
+        set_member_details(mock_strategy, details, user=test_user, response=response)
+
+        assert test_user.is_staff is has_admin_group
+
+    def test_handles_missing_admin_flag(self, mock_strategy, test_user):
+        """Test behavior when is_admin is not in details"""
+        details = {
+            "preferred_name": fake.name(),
+            "member_number": fake.random_int(min=1000, max=9999),
+        }
+        response = {}
+
+        # Store original values
+        original_staff = test_user.is_staff
+
+        set_member_details(mock_strategy, details, user=test_user, response=response)
+
+        # Values should remain unchanged
+        assert test_user.is_staff == original_staff
+
+    @admin_permissions_param
+    @hugo_permissions_param
+    def test_integration_with_full_pipeline(
+        self, mock_strategy, test_user, has_admin_group, can_nominate, can_vote
+    ):
+        """Test set_member_details with full pipeline data"""
+        response = generate_auth_response(
+            has_admin_group=has_admin_group,
+            can_nominate=can_nominate,
+            can_vote=can_vote,
+        )
+        details = {}
+
+        # Run pipeline functions to populate details
+        adapt_regid_to_username(mock_strategy, details, test_user, response=response)
+        get_wsfs_permissions(mock_strategy, details, test_user, response=response)
+        adapt_personal_information(mock_strategy, details, test_user, response=response)
+
+        # Now set member details
+        set_member_details(mock_strategy, details, user=test_user, response=response)
+
+        # Should set admin permissions based on response data
+        assert test_user.is_staff is has_admin_group
+
+        # Verify that user details include the voting/nominating permissions
+        assert details["can_nominate"] is can_nominate
+        assert details["can_vote"] is can_vote
+
+    def test_ignores_fields_not_on_user_model(self, mock_strategy, test_user):
+        """Test that fields not on user model are safely ignored"""
+        details = {
+            "preferred_name": fake.name(),
+            "member_number": fake.random_int(min=1000, max=9999),
+            "is_admin": True,  # This should still work for standard fields
+        }
+        response = {}
+
+        # Should not raise AttributeError even if user doesn't have custom fields
+        set_member_details(mock_strategy, details, user=test_user, response=response)
+
+        # Standard fields should still be set
+        assert test_user.is_staff is True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,12 @@ known-first-party = ["", "lacon_v_app"]
 dev = [
     "djlint>=1.36.4",
     "factory-boy~=3.3.0",
+    "faker>=37.6.0",
+    "icecream>=2.1.8",
     "nomnom-hugoawards",
     "pytest~=8.3.3",
     "pytest-django~=4.9.0",
+    "pytest-xdist>=3.8.0",
     "ruff>=0.14.4",
 ]
 

--- a/scripts/ensure_env.sh
+++ b/scripts/ensure_env.sh
@@ -24,8 +24,10 @@ NOM_REDIS_HOST=localhost
 NOM_REDIS_PORT=6379
 NOM_ALLOWED_HOSTS=127.0.0.1,localhost
 
-NOM_OAUTH_KEY=bogon
-NOM_OAUTH_SECRET=bogon
+NOM_OAUTH_CLIENT_ID=bogon
+NOM_OAUTH_CLIENT_SECRET=bogon
+# default to authentik staging's development app
+NOM_AUTHENTIK_OIDC_ENDPOINT=https://auth-staging.lacon.org/application/o/nom-nom-development
 
 NOM_EMAIL_HOST=localhost
 NOM_EMAIL_PORT=51025

--- a/seed/all/0001-permissions.json
+++ b/seed/all/0001-permissions.json
@@ -18,15 +18,6 @@
         "fields": {
             "name": "WSFS Administrator",
             "permissions": [
-                ["add_proposal", "advise", "proposal"],
-                ["change_proposal", "advise", "proposal"],
-                ["delete_proposal", "advise", "proposal"],
-                ["view_proposal", "advise", "proposal"],
-                ["view_vote", "advise", "vote"],
-                ["add_voteadmindata", "advise", "voteadmindata"],
-                ["change_voteadmindata", "advise", "voteadmindata"],
-                ["delete_voteadmindata", "advise", "voteadmindata"],
-                ["view_voteadmindata", "advise", "voteadmindata"],
                 ["change_user", "auth", "user"],
                 ["delete_user", "auth", "user"],
                 ["view_user", "auth", "user"],
@@ -211,24 +202,6 @@
         "fields": {
             "name": "Preview Packet",
             "permissions": [["preview_packet", "hugopacket", "electionpacket"]]
-        }
-    },
-    {
-        "model": "auth.group",
-        "fields": {
-            "name": "WSFS Business Meeting Admin",
-            "permissions": [
-                ["add_proposal", "advise", "proposal"],
-                ["can_preview", "advise", "proposal"],
-                ["change_proposal", "advise", "proposal"],
-                ["delete_proposal", "advise", "proposal"],
-                ["view_proposal", "advise", "proposal"],
-                ["view_vote", "advise", "vote"],
-                ["add_voteadmindata", "advise", "voteadmindata"],
-                ["change_voteadmindata", "advise", "voteadmindata"],
-                ["delete_voteadmindata", "advise", "voteadmindata"],
-                ["view_voteadmindata", "advise", "voteadmindata"]
-            ]
         }
     }
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asttokens"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978, upload-time = "2024-11-30T04:30:14.439Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918, upload-time = "2024-11-30T04:30:10.946Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -725,6 +734,24 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
 name = "factory-boy"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -808,6 +835,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/1d/3062fcc89ee05a715c0b9bfe6490c00c576314f27ffee3a704122c6fd259/humanize-4.13.0.tar.gz", hash = "sha256:78f79e68f76f0b04d711c4e55d32bebef5be387148862cb1ef83d2b58e7935a0", size = 81884, upload-time = "2025-08-25T09:39:20.04Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/c7/316e7ca04d26695ef0635dc81683d628350810eb8e9b2299fc08ba49f366/humanize-4.13.0-py3-none-any.whl", hash = "sha256:b810820b31891813b1673e8fec7f1ed3312061eab2f26e3fa192c393d11ed25f", size = 128869, upload-time = "2025-08-25T09:39:18.54Z" },
+]
+
+[[package]]
+name = "icecream"
+version = "2.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "colorama" },
+    { name = "executing" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/be/a89ec4132ddb4481f9587f736b8a01a07378f9e71de73549223ff1cd41f7/icecream-2.1.8.tar.gz", hash = "sha256:37269bbc62b02f0d85bfaf3a0eb4df272c967fad059f7ddcdaee5303ea2b2a62", size = 18337, upload-time = "2025-09-14T09:31:09.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/5f/f877d2cfcad41c0db98b120872f67b805fde5e6d407e584e9edfc9dec35c/icecream-2.1.8-py3-none-any.whl", hash = "sha256:10b1c39dcb54cb28eb487bac56c35dbf9c2b2f406d24340e1a615c3f17274852", size = 15714, upload-time = "2025-09-14T09:31:08.647Z" },
 ]
 
 [[package]]
@@ -914,9 +956,12 @@ dependencies = [
 dev = [
     { name = "djlint" },
     { name = "factory-boy" },
+    { name = "faker" },
+    { name = "icecream" },
     { name = "nomnom-hugoawards" },
     { name = "pytest" },
     { name = "pytest-django" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -932,9 +977,12 @@ requires-dist = [
 dev = [
     { name = "djlint", specifier = ">=1.36.4" },
     { name = "factory-boy", specifier = "~=3.3.0" },
-    { name = "nomnom-hugoawards" },
+    { name = "faker", specifier = ">=37.6.0" },
+    { name = "icecream", specifier = ">=2.1.8" },
+    { name = "nomnom-hugoawards", editable = "../nomnom" },
     { name = "pytest", specifier = "~=8.3.3" },
     { name = "pytest-django", specifier = "~=4.9.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.14.4" },
 ]
 
@@ -1137,6 +1185,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1182,6 +1239,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/c0/43c8b2528c24d7f1a48a47e3f7381f5ab2ae8c64634b0c3f4bd843063955/pytest_django-4.9.0.tar.gz", hash = "sha256:8bf7bc358c9ae6f6fc51b6cebb190fe20212196e6807121f11bd6a3b03428314", size = 84067, upload-time = "2024-09-02T15:49:18.407Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/fe/54f387ee1b41c9ad59e48fb8368a361fad0600fe404315e31a12bacaea7d/pytest_django-4.9.0-py3-none-any.whl", hash = "sha256:1d83692cb39188682dbb419ff0393867e9904094a549a7d38a3154d5731b2b99", size = 23723, upload-time = "2024-09-02T15:49:17.127Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implement the full OAuth + Authentik integration for NomNom

### Mappings
- `reg-id` in the payload is mapped to both the username (used for uniqueness) and the member number
- `hugos-can-vote` and `hugos-can-nominate` are associated with the related permission groups
- The presence of the `App Admin` group manifests as the member being marked as staff (and therefore granted access to the NomNom admin dashboard) (up for debate!) 
- The preferred name identified in Authentik is used if possible, followed by given name, then nickname (up for debate!) 

### Changes
- settings for authentication
- authentication pipeline integrating with social auth
- add faker dependency
- settings cleanup
- added pipeline tests in some detail
- removed advisory vote seeds, since LACon isn't using the feature