### PR TITLE
Text updates

### DIFF
--- a/deploy/bin/psql
+++ b/deploy/bin/psql
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 WORKING_DIR=$(
-    sudo docker inspect seattle-2025-web-1 |
+    sudo docker inspect lacon-v-web-1 |
         jq -r '.[0].Config.Labels["com.docker.compose.project.working_dir"]'
 )
 
 COMPOSE_FILE=$(
-    sudo docker inspect seattle-2025-web-1 |
+    sudo docker inspect lacon-v-web-1 |
         jq -r '.[0].Config.Labels["com.docker.compose.project.config_files"]'
 )
 

--- a/deploy/docker-compose.example.yml
+++ b/deploy/docker-compose.example.yml
@@ -1,9 +1,9 @@
 # This is a sample deployment service configuration, based
-# on the production deployment for Seattle in 2025. Modify this
+# on the production deployment for LACon V. Modify this
 # if you want to use docker-compose to run nomnom.
 #
 # It depends on the creation of a valid `.env` file, a sample
-# of which you can find in the [Seattle in 2025 repo](https://github.com/LAConOrg/lacon-v/blob/main/deploy/production/.env.template).
+# of which you can find in the [LACon V repo](https://github.com/LAConOrg/lacon-v/blob/main/deploy/production/.env.template).
 name: "nomnom"
 x-image: &image
   image: ghcr.io/your-org/your-convention:${NOMNOM_VERSION:-main}

--- a/deploy/production/compose.yml
+++ b/deploy/production/compose.yml
@@ -137,7 +137,7 @@ services:
   # This container and Dozzle provide a logging endpoint access over my personal tailnet,
   # so that I can view the container logs on this host without ssh as needed.
   tailscale-sidecar:
-    hostname: nomnom-seattle2025-prod-logs
+    hostname: nomnom-lacon-prod-logs
     volumes:
       - tailscale-data:/var/lib/tailscale
     devices:
@@ -155,7 +155,7 @@ services:
     network_mode: "service:tailscale-sidecar"
     restart: unless-stopped
     environment:
-      DOZZLE_HOSTNAME: "nomnom-seattle2025-prod-logs"
+      DOZZLE_HOSTNAME: "nomnom-lacon-prod-logs"
       DOZZLE_AUTH_PROVIDER: forward-proxy
       DOZZLE_AUTH_HEADER_USER: "Tailscale-User-Login"
       DOZZLE_AUTH_HEADER_NAME: "Tailscale-User-Name"

--- a/deploy/proxy/502.html
+++ b/deploy/proxy/502.html
@@ -89,7 +89,7 @@
                 </p>
                 <p>
                     Please try again in a minute or so; if there is an extended outage,
-                    please check the Seattle in 2025 social media for updates
+                    please check the LACon V social media for updates
                 </p>
                 <p>-- NomNom</p>
             </div>

--- a/deploy/staging/compose.yml
+++ b/deploy/staging/compose.yml
@@ -100,7 +100,7 @@ services:
   # This container and Dozzle provide a logging endpoint access over my personal tailnet,
   # so that I can view the container logs on this host without ssh as needed.
   tailscale-sidecar:
-    hostname: ${LOGGING_HOSTNAME:-nomnom-seattle2025-staging-logs}
+    hostname: ${LOGGING_HOSTNAME:-nomnom-lacon-staging-logs}
     volumes:
       - tailscale-data:/var/lib/tailscale
     devices:
@@ -118,7 +118,7 @@ services:
     network_mode: "service:tailscale-sidecar"
     restart: unless-stopped
     environment:
-      DOZZLE_HOSTNAME: "nomnom-seattle2025-staging-logs"
+      DOZZLE_HOSTNAME: "nomnom-lacon-staging-logs"
       DOZZLE_AUTH_PROVIDER: forward-proxy
       DOZZLE_AUTH_HEADER_USER: "Tailscale-User-Login"
       DOZZLE_AUTH_HEADER_NAME: "Tailscale-User-Name"

--- a/lacon_v_app/templates/bits/login_forms.html
+++ b/lacon_v_app/templates/bits/login_forms.html
@@ -2,27 +2,37 @@
 {% load django_bootstrap5 %}
 <div class="col-12 text-center">
     <h1 class="title font-weight-bold">Log In</h1>
-    <div id="login">
+    <div id="login" class="mb-5">
+        <a href="{% url "social:begin" "lacon" %}?next={{ request.path }}">
+            <button class="d-inline-flex align-items-center btn btn-primary btn-lg px-4 rounded-pill"
+                    type="button">Log in with {{ CONVENTION_NAME }} Registration</button>
+        </a>
+        
         {% if USERNAME_LOGIN %}
-            <form method="POST"
-                  action="{% url "login" %}?next={{ request.path }}"
-                  accept-charset="UTF-8">
-                {% bootstrap_form form %}
-                {% csrf_token %}
-                <div>
-                    <input class="btn btn-primary login-btn" type="submit" value="Login">
+            <div class="mt-3">
+                <button class="btn btn-outline-secondary" 
+                        type="button" 
+                        data-bs-toggle="collapse" 
+                        data-bs-target="#usernameLoginForm" 
+                        aria-expanded="false" 
+                        aria-controls="usernameLoginForm">
+                    Or log in with username
+                </button>
+                
+                <div class="collapse mt-3" id="usernameLoginForm">
+                    <div class="card card-body">
+                        <form method="POST"
+                              action="{% url "login" %}?next={{ request.path }}"
+                              accept-charset="UTF-8">
+                            {% bootstrap_form form %}
+                            {% csrf_token %}
+                            <div>
+                                <input class="btn btn-primary login-btn" type="submit" value="Login">
+                            </div>
+                        </form>
+                    </div>
                 </div>
-            </form>
-        {% else %}
-            Username login has been disabled. Either set USERNAME_LOGIN to True in Settings
-            or add a convention app to settings with NOM_CONVENTION_APP and provide
-            a different login scheme.
+            </div>
         {% endif %}
-        <div class="d-inline-flex gap-2 mb-5">
-            <a href="{% url "social:begin" "lacon" %}?next={{ request.path }}">
-                <button class="d-inline-flex align-items-center btn btn-primary btn-lg px-4 rounded-pill"
-                        type="button">Log in with {{ CONVENTION_NAME }} Registration</button>
-            </a>
-        </div>
     </div>
 </div>

--- a/lacon_v_app/templates/nominate/bits/nomination_instructions.html
+++ b/lacon_v_app/templates/nominate/bits/nomination_instructions.html
@@ -10,4 +10,3 @@ It will have access to:
 {% endcomment %}
 <h1>Nominate Good Things!</h1>
 <p>The Hugo Awards recognize Good Things™ in SF/F. Suggest to us some!</p>
-<p>雨果奖表役科幻/奇幻领域中的佳作。推荐一些给我们吧！</p>


### PR DESCRIPTION
- drop the chinese text in the nominating instructions
- 502 error page now references LACon V
- docker log tailnet names are LACon hosts
- psql command now references the lacon-v container
- clean up the main login form when username is disabled