### PR TITLE
Minor Hugo Packet welcome doc fixes: make the in-page header <h2>

### DIFF
--- a/lacon_v_app/templates/hugopacket/bits/welcome.html
+++ b/lacon_v_app/templates/hugopacket/bits/welcome.html
@@ -1,4 +1,4 @@
-<h1>Welcome to the 2026 Hugo Voter Packet!</h1>
+<h2>Welcome to the 2026 Hugo Voter Packet!</h2>
 <p>The material in the Packet is provided only for the use of members of LAcon, Worldcon 2026. <strong>Please don't distribute Packet materials to others.</strong></p>
 <p>You can download Packet materials in the following ways:</p>
 <ul>


### PR DESCRIPTION
There's already an `<h1>` header at the top of https://nomnom.lacon.org/p/the-hugo-awards/ so it'll look better if this second header is `<h2>`.