### PR TITLE
Wordsmith section show/hide text to match how it's used for 2026 packet

### DIFF
--- a/lacon_v_app/templates/hugopacket/bits/section.html
+++ b/lacon_v_app/templates/hugopacket/bits/section.html
@@ -39,7 +39,7 @@
                                         data-bs-target="#finalists-category-{{ section_data.section.id }}"
                                         aria-expanded="false"
                                         aria-controls="finalists-category-{{ section_data.section.id }}">
-                                    Show all downloads
+                                    Show individual downloads
                                 </button>
                             </div>
                         </div>

--- a/lacon_v_app/templates/hugopacket/bits/section.html
+++ b/lacon_v_app/templates/hugopacket/bits/section.html
@@ -1,0 +1,90 @@
+{% load markdownify %}
+<div class="row mt-4">
+    <div class="col-12">
+        <div class="section-container" style="margin-left: {{ depth }}rem;">
+            {% if depth == 0 %}
+                {# Check if this is a packet-level section (no subsections) or category (has subsections) #}
+                {% if not section_data.subsections %}
+                    {# Packet-level section (e.g., "Full Packet") - always visible #}
+                    <div class="packet-level-section">
+                        <h2>{{ section_data.section.name }}</h2>
+                        {% if section_data.section.description %}
+                            <div class="section-description mb-3">{{ section_data.section.description|markdownify }}</div>
+                        {% endif %}
+                        {# All files in packet-level section are always visible #}
+                        {% for packet_file in section_data.files %}
+                            {% include "hugopacket/bits/packet_file.html" with packet=packet_file %}
+                            {% if not forloop.last %}<hr>{% endif %}
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    {# Category section (e.g., "Best Novel") with collapsible finalists #}
+                    <div class="category-section">
+                        <div class="category-header">
+                            <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-start gap-2">
+                                <div>
+                                    <h2>{{ section_data.section.name }}</h2>
+                                    {% if section_data.section.description %}
+                                        <div class="section-description mb-3">{{ section_data.section.description|markdownify }}</div>
+                                    {% endif %}
+                                    {# Category-level files (e.g., "Best Novel - Complete Packet") - always visible #}
+                                    {% for packet_file in section_data.files %}
+                                        {% include "hugopacket/bits/packet_file.html" with packet=packet_file %}
+                                        {% if not forloop.last %}<hr>{% endif %}
+                                    {% endfor %}
+                                </div>
+                                {# Expand/Collapse button for all finalists in this category #}
+                                <button class="btn btn-sm btn-outline-primary expand-collapse-btn ms-3"
+                                        data-bs-toggle="collapse"
+                                        data-bs-target="#finalists-category-{{ section_data.section.id }}"
+                                        aria-expanded="false"
+                                        aria-controls="finalists-category-{{ section_data.section.id }}">
+                                    Show all downloads
+                                </button>
+                            </div>
+                        </div>
+                        {# Collapsible container for ALL finalists in this category #}
+                        <div class="collapse finalist-container"
+                             id="finalists-category-{{ section_data.section.id }}">
+                            {% for subsection_data in section_data.subsections %}
+                                {% include "hugopacket/bits/section.html" with section_data=subsection_data depth=depth|add:1 %}
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endif %}
+            {% elif depth == 1 %}
+                {# Finalist subsection - rendered within category's collapsible container #}
+                <div class="finalist-item">
+                    <h3>{{ section_data.section.name }}</h3>
+                    {% if section_data.section.description %}
+                        <div class="section-description mb-3">{{ section_data.section.description|markdownify }}</div>
+                    {% endif %}
+                    {% for packet_file in section_data.files %}
+                        {% include "hugopacket/bits/packet_file.html" with packet=packet_file %}
+                        {% if not forloop.last %}<hr>{% endif %}
+                    {% endfor %}
+                    {% for subsection_data in section_data.subsections %}
+                        {% include "hugopacket/bits/section.html" with section_data=subsection_data depth=depth|add:1 %}
+                    {% endfor %}
+                </div>
+            {% else %}
+                {# Deeper nesting levels (depth >= 2) - not collapsible #}
+                {% if depth == 2 %}
+                    <h4>{{ section_data.section.name }}</h4>
+                {% else %}
+                    <h5>{{ section_data.section.name }}</h5>
+                {% endif %}
+                {% if section_data.section.description %}
+                    <div class="section-description mb-3">{{ section_data.section.description|markdownify }}</div>
+                {% endif %}
+                {% for packet_file in section_data.files %}
+                    {% include "hugopacket/bits/packet_file.html" with packet=packet_file %}
+                    {% if not forloop.last %}<hr>{% endif %}
+                {% endfor %}
+                {% for subsection_data in section_data.subsections %}
+                    {% include "hugopacket/bits/section.html" with section_data=subsection_data depth=depth|add:1 %}
+                {% endfor %}
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/lacon_v_app/templates/hugopacket/index.html
+++ b/lacon_v_app/templates/hugopacket/index.html
@@ -101,7 +101,7 @@ document.addEventListener('DOMContentLoaded', function() {
         collapseEl.addEventListener('shown.bs.collapse', function() {
             const btn = document.querySelector('[data-bs-target="#' + collapseEl.id + '"]');
             if (btn) {
-                btn.textContent = 'Show only main download';
+                btn.textContent = 'Hide individual downloads';
                 btn.classList.remove('btn-outline-primary');
                 btn.classList.add('btn-outline-danger');
             }
@@ -111,7 +111,7 @@ document.addEventListener('DOMContentLoaded', function() {
         collapseEl.addEventListener('hidden.bs.collapse', function() {
             const btn = document.querySelector('[data-bs-target="#' + collapseEl.id + '"]');
             if (btn) {
-                btn.textContent = 'Show all downloads';
+                btn.textContent = 'Show individual downloads';
                 btn.classList.remove('btn-outline-danger');
                 btn.classList.add('btn-outline-primary');
             }

--- a/lacon_v_app/templates/hugopacket/index.html
+++ b/lacon_v_app/templates/hugopacket/index.html
@@ -1,0 +1,122 @@
+{% extends "base.html" %}
+{% load markdownify %}
+{% block extra_css %}
+    <style>
+    /* Packet-level section styling */
+    .packet-level-section {
+        padding: 0.75rem;
+        background: #f8f9fa;
+        border-left: 3px solid #28a745;
+        margin-bottom: 1rem;
+    }
+
+    /* Category section styling */
+    .category-section {
+        margin-bottom: 1.5rem;
+    }
+
+    .category-header {
+        padding: 0.75rem;
+        background: #f8f9fa;
+        border-left: 3px solid #0066cc;
+        margin-bottom: 0.5rem;
+    }
+
+    .category-header-content {
+        display: flex;
+        justify-content: space-between;
+        align-items: start;
+        gap: 1rem;
+    }
+
+    /* Finalist container and items */
+    .finalist-container {
+        background: white;
+        border: 1px solid #dee2e6;
+        margin-bottom: 1rem;
+    }
+
+    .finalist-item {
+        padding: 0.75rem;
+        border-bottom: 1px solid #dee2e6;
+        background: #fafafa;
+    }
+
+    .finalist-item:last-child {
+        border-bottom: none;
+    }
+
+    /* Button styling */
+    .expand-collapse-btn {
+        white-space: nowrap;
+        flex-shrink: 0;
+    }
+
+    /* Section description styling */
+    .section-description {
+        color: #666;
+        font-size: 0.9em;
+    }
+    </style>
+{% endblock %}
+{% block content %}
+    <div class="p-5 bg-body-tertiary">
+        <div class="row">
+            <div class="col-12">
+                <h1 class="text-center">{{ packet.name }}</h1>
+                {% if not packet.enabled %}
+                    <div class="alert alert-warning">
+                        You have been given preview access to the packet; please
+                        be aware that it might change, and that the contents are
+                        not to be shared until it is made public.
+                    </div>
+                {% endif %}
+                {% include "hugopacket/bits/welcome.html" %}
+            </div>
+        </div>
+        {% for section_data in section_tree %}
+            {% include "hugopacket/bits/section.html" with section_data=section_data depth=0 %}
+        {% endfor %}
+        {% if orphan_files %}
+            <div class="row mt-4">
+                <div class="col-12">
+                    <h2>Other Files</h2>
+                    {% for packet_file in orphan_files %}
+                        {% include "hugopacket/bits/packet_file.html" with packet=packet_file %}
+                        {% if not forloop.last %}<hr>{% endif %}
+                    {% endfor %}
+                </div>
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}
+{% block extra_js %}
+    <script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Get all collapse elements
+    const collapseElements = document.querySelectorAll('.collapse');
+    
+    collapseElements.forEach(function(collapseEl) {
+        // Listen for collapse shown event (when expanding)
+        collapseEl.addEventListener('shown.bs.collapse', function() {
+            const btn = document.querySelector('[data-bs-target="#' + collapseEl.id + '"]');
+            if (btn) {
+                btn.textContent = 'Show only main download';
+                btn.classList.remove('btn-outline-primary');
+                btn.classList.add('btn-outline-danger');
+            }
+        });
+        
+        // Listen for collapse hidden event (when collapsing)
+        collapseEl.addEventListener('hidden.bs.collapse', function() {
+            const btn = document.querySelector('[data-bs-target="#' + collapseEl.id + '"]');
+            if (btn) {
+                btn.textContent = 'Show all downloads';
+                btn.classList.remove('btn-outline-danger');
+                btn.classList.add('btn-outline-primary');
+            }
+        });
+    });
+});
+    </script>
+{% endblock %}


### PR DESCRIPTION
In the 2026 packet, each section contains items for individual works, so we think the clearest concise wording is for the section level toggles to say "Show/hide individual downloads."

Note: i left this PR as two separate commits:
* one to copy the unmodified files `section.html` and `index.html` from nomnom
* one to actually make the change

I think it's clearer for anyone looking at the repo in the future to have those as separate commits in the commit trail, so my inclination would be to leave it that way, but if you prefer something else, i can rebase.