### PR TITLE
Update number of included finalists at top of downloads page

### DIFF
--- a/lacon_v_app/templates/hugopacket/bits/welcome.html
+++ b/lacon_v_app/templates/hugopacket/bits/welcome.html
@@ -7,5 +7,5 @@
   <li>Download the materials for a specific finalist.</li>
 </ul>
 <p>Evaluation codes are available for some of the Best Game finalists. Codes are limited, so please only request one if you haven't played the game and plan to do so.</p>
-<p>The download for each category includes a table of contents document with more information about the materials in that category. Almost every category includes material from all 6 finalists in the category, except for the following: Best Dramatic Presentation, Long Form (5 finalists); Best Game (5 finalists); Professional Artist (5 finalists); and Lodestar (4 finalists).</p>
+<p>The download for each category includes a table of contents document with more information about the materials in that category. Almost every category includes material from all 6 finalists in the category, except for the following: Best Dramatic Presentation, Long Form (5 finalists); Best Game (5 finalists); Professional Artist (5 finalists); and Lodestar (5 finalists).</p>
 <p>If you have questions about the Packet or need assistance, please contact us at <a href="mailto:hugo-help@lacon.org">hugo-help@lacon.org</a>.</p>


### PR DESCRIPTION
We ended up receiving one more finalist’s Packet materials, so this number changed from 4 to 5.