### PR TITLE
Version bumps

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -350,16 +350,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.12"
+version = "5.2.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/55/b9445fc0695b03746f355c05b2eecc54c34e05198c686f4fc4406b722b52/django-5.2.12.tar.gz", hash = "sha256:6b809af7165c73eff5ce1c87fdae75d4da6520d6667f86401ecf55b681eb1eeb", size = 10860574, upload-time = "2026-03-03T13:56:05.509Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/e3/31722f7284c9f43333daff9aee9184678e4487adcb5506af0db8cea09ce1/django-5.2.15.tar.gz", hash = "sha256:5154a9bf84ac01dde011e367f355c07dbb329532e06810dcf3ef2af269e236e7", size = 10873669, upload-time = "2026-06-03T13:03:35.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/32/4b144e125678efccf5d5b61581de1c4088d6b0286e46096e3b8de0d556c8/django-5.2.12-py3-none-any.whl", hash = "sha256:4853482f395c3a151937f6991272540fcbf531464f254a347bf7c89f53c8cff7", size = 8310245, upload-time = "2026-03-03T13:56:01.174Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/38140b1643c00d5c46ce69c78e6980fd285aee223100319631bedee4f5e7/django-5.2.15-py3-none-any.whl", hash = "sha256:0eb4a9bb1853a35b0286dbc6d916bd352c8c2687195a7f2d6f80cefd840e4970", size = 8311957, upload-time = "2026-06-03T13:03:31.329Z" },
 ]
 
 [[package]]
@@ -1127,7 +1127,7 @@ wheels = [
 
 [[package]]
 name = "nomnom-hugoawards"
-version = "2026.10.0"
+version = "2026.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -1178,9 +1178,9 @@ dependencies = [
     { name = "svcs" },
     { name = "whitenoise" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/a1/f128ae637cd9e36fcb785a7d5cd16a961a013ca242067545b8e29a76ac82/nomnom_hugoawards-2026.10.0.tar.gz", hash = "sha256:f597a393453be26edf25f0206cc668e682b63f24626a39a1df6de27de038f389", size = 2740464, upload-time = "2026-05-09T03:53:50.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/61/c4624e6a8316678e0985c16b6017fb838d42509ca7a382dde9964a96cce9/nomnom_hugoawards-2026.10.1.tar.gz", hash = "sha256:e0518c6be6b06893899101cd28421353206ffa01d7dfc33a215272ee0d9c5d6b", size = 2745116, upload-time = "2026-06-03T15:37:33.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/b3/36ecc2ac50d6d01d810ed453522b472e51f8323934dfe6a32df2553b010b/nomnom_hugoawards-2026.10.0-py3-none-any.whl", hash = "sha256:cdac9e285df484b47b001fb659da2f0937e3db384fbd4ef653d529feba3d9ab8", size = 2525970, upload-time = "2026-05-09T03:53:47.689Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d2/444abae8e7677ea5557c809ee438f03ec463d2f83dbaab00c7c61300ff55/nomnom_hugoawards-2026.10.1-py3-none-any.whl", hash = "sha256:4bf32e5e93e33328956100aae42abe0938656754c8fbbddffe8e15061251486e", size = 2526945, upload-time = "2026-06-03T15:37:31.081Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- nomnom 2026.10.1 with fixes to the voting UI and minor counting improvements
- django security update